### PR TITLE
Fix double base64 encoding bug when downloading GDShare files

### DIFF
--- a/history/views.py
+++ b/history/views.py
@@ -326,7 +326,7 @@ def download_record(request, record_id=None, online_id=None):
 	except: return render(request, 'error.html', {'error': 'Record not found in our database'})
 	if record.level.is_public is not True:
 		return render(request, 'error.html', {'error': 'You do not have the rights to download this record'})
-	data = ccUtils.create_data_from_level_record(record, True, False) #gdshare b64s the b64d desc already, so this is required
+	data = ccUtils.create_data_from_level_record(record, False, False) #gdshare takes a normal b64 description, so there is no need for double b64
 	if 'k4' not in data:
 		return render(request, 'error.html', {'error': 'This record does not contain any level data. If you have reached this page using a link claiming that the data is available, please report this bug immediately.'})
 


### PR DESCRIPTION
GDShare takes a normal, base64 encoded description, as returned by the server. There is no need to encode it twice, in fact, this prevents you from viewing the original description.