### PR TITLE
Update level preview link

### DIFF
--- a/history/templates/level.html
+++ b/history/templates/level.html
@@ -79,7 +79,7 @@
 	</div>
 	<div class="col-md-8" style="padding-right:0px">
 		<img class="round-border" style="max-width:100%;max-height:100%;aspect-ratio: 16/9;"
-        src="https://raw.githubusercontent.com/cdc-sys/level-thumbnails/main/thumbs/{{ online_id }}.png"
+        src="https://tjcsucht.net/levelthumbs/{{ online_id }}.png"
         onerror="this.onerror=null;this.src='https://cvolton.eu/gdhistory_placeholder2.webp';">
 	</div>
 </div>

--- a/history/templates/level.html
+++ b/history/templates/level.html
@@ -79,7 +79,8 @@
 	</div>
 	<div class="col-md-8" style="padding-right:0px">
 		<img class="round-border" style="max-width:100%;max-height:100%;aspect-ratio: 16/9;"
-			src="https://cvolton.eu/gdhistory_placeholder2.webp">
+        src="https://raw.githubusercontent.com/cdc-sys/level-thumbnails/main/thumbs/{{ online_id }}.png"
+        onerror="this.onerror=null;this.src='https://cvolton.eu/gdhistory_placeholder2.webp';">
 	</div>
 </div>
 


### PR DESCRIPTION
The database for LevelThumbnails moved off of Github, so levels do not have images on the site anymore. This fixes that by replacing the link with that of the new database.